### PR TITLE
Initial support for ABB EV3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a Python module that implements the communication to several electricity
 
 At the moment, the following meters are supported:
 
-* ABB B21, B23, A43 and similar ABB meters (Modbus Serial)
+* ABB B21, B23, A43, EV3 and similar ABB meters (Modbus Serial)
 * SMA SunnyBoy (Modbus TCP)
 * MultiCube meters
 
@@ -30,6 +30,15 @@ data = meter.read()
 ```
 
 This returns a dictionary with all key-value pairs of data.
+
+To read all resgisters from ABB EV3 (using default serial values 9600, 8E1):
+```
+from energymeter import ABBMeter
+import serial
+
+meter = ABBMeter(port="/dev/ttyUSB0", baudrate=9600, parity=serial.PARITY_EVEN, slaveaddress=1, model="EV3")
+data = meter.read()
+```
 
 To read a single register:
 


### PR DESCRIPTION
This PR adds initial support for ABB EV3 012-100, serial parity and debug options. Some supported fields for EV3 still need some changes from documentation, eg number of decimal places and unsigned/signed.

Here is the documentation and modbus map: https://new.abb.com/products/2CMA290881R1000/ev3-012-100

Here is one output for EV3 with debug mode enabled:
```
MinimalModbus debug mode. Create serial port /dev/ttyUSB0
MinimalModbus debug mode. Will write to instrument (expecting 29 bytes back): 01 03 50 00 00 0C 54 CF (8 bytes)
MinimalModbus debug mode. Clearing serial buffers for port /dev/ttyUSB0
MinimalModbus debug mode. No sleep required before write. Time since previous read: 8993168.17 ms, minimum silent period: 4.01 ms.
MinimalModbus debug mode. Response from instrument: 01 03 18 00 00 00 00 03 C5 FE C3 00 00 00 00 00 50 D3 72 00 00 00 00 03 75 2B 51 6E 99 (29 bytes), roundtrip time: 0.1 ms. Timeout for reading: 500.0 ms.

MinimalModbus debug mode. Will write to instrument (expecting 77 bytes back): 01 03 54 60 00 24 55 FF (8 bytes)
MinimalModbus debug mode. Clearing serial buffers for port /dev/ttyUSB0
MinimalModbus debug mode. No sleep required before write. Time since previous read: 16.47 ms, minimum silent period: 4.01 ms.
MinimalModbus debug mode. Response from instrument: 01 03 48 00 00 00 00 00 18 51 01 00 00 00 00 00 F8 B4 F4 00 00 00 00 02 B6 05 2C 00 00 00 00 00 1A DF 1D 00 00 00 00 00 1B 64 D5 00 00 00 00 00 1B 9B E4 FF FF FF FF FF FD 71 E4 00 00 00 00 00 DD 50 1F 00 00 00 00 02 9A 69 48 83 34 (77 bytes), roundtrip time: 0.1 ms. Timeout for reading: 500.0 ms.

MinimalModbus debug mode. Will write to instrument (expecting 129 bytes back): 01 03 5B 00 00 3E D7 3E (8 bytes)
MinimalModbus debug mode. Clearing serial buffers for port /dev/ttyUSB0
MinimalModbus debug mode. No sleep required before write. Time since previous read: 23.98 ms, minimum silent period: 4.01 ms.
MinimalModbus debug mode. Response from instrument: 01 03 7C 00 00 09 1A 00 00 09 16 00 00 09 0A 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 7D 00 00 00 61 00 00 03 06 00 00 00 00 00 03 3E 73 00 00 45 A5 00 00 3C 84 00 02 BC 4A 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 13 89 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 03 E4 03 9A 03 30 03 E8 CE 4B (129 bytes), roundtrip time: 0.2 ms. Timeout for reading: 500.0 ms.

{'active_export': 52970.1,
 'active_export_l1': 17610.53,
 'active_export_l2': 17952.85,
 'active_export_l3': 18093.8,
 'active_import': 633074.59,
 'active_import_l1': 15936.01,
 'active_import_l2': 162992.52,
 'active_import_l3': 454833.08,
 'active_net': 580104.49,
 'active_net_l1': -1674.52,
 'active_net_l2': 145039.67,
 'active_net_l3': 436739.28,
 'active_power_l1': 178.29,
 'active_power_l2': 154.92,
 'active_power_l3': 1792.74,
 'active_power_total': 2125.95,
 'current_l1': 1.25,
 'current_l2': 0.97,
 'current_l3': 7.74,
 'frequency': 50.01,
 'phase_angle_power_total': 0.0,
 'power_factor_l1': 0.922,
 'power_factor_l2': 0.816,
 'power_factor_l3': 1.0,
 'power_factor_total': 0.996,
 'reactive_power_total': 0.0,
 'voltage_l1_l2': 0.0,
 'voltage_l1_l3': 0.0,
 'voltage_l1_n': 233.0,
 'voltage_l2_n': 232.6,
 'voltage_l3_l2': 0.0,
 'voltage_l3_n': 231.4}
```